### PR TITLE
Fixed broken link to PDF

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ To process a batch:
     # Write a PDF report with every sequenticon
     sequenticon_batch_pdf(sequences, "my_report.pdf")
 
-Here is an example PDF output from the last command (`full PDF <https://github.com/Edinburgh-Genome-Foundry/sequenticon/blob/master/docs/example_report.pdf">`_):
+Here is an example PDF output from the last command (`full PDF <https://github.com/Edinburgh-Genome-Foundry/sequenticon/blob/master/docs/example_report.pdf>`_):
 
 .. raw:: html
 


### PR DESCRIPTION
When clicking the on `full PDF` I get a 404 error. After removing the `"` at the end of the string it works for me. 
Cool project :)