### PR TITLE
Add the actual license name in the license text

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author='Zulko',
     description='Generate human-friendly icons from DNA sequences',
     long_description=open('pypi-readme.rst').read(),
-    license='see LICENSE.txt',
+    license='MIT License',
     keywords="DNA sequence barcoding sequenticon identicon hash",
     packages=find_packages(exclude='docs'),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author='Zulko',
     description='Generate human-friendly icons from DNA sequences',
     long_description=open('pypi-readme.rst').read(),
-    license='MIT License',
+    license='MIT',
     keywords="DNA sequence barcoding sequenticon identicon hash",
     packages=find_packages(exclude='docs'),
     include_package_data=True,


### PR DESCRIPTION
This makes it possible for tools to inspect the license of installed packages.