### PR TITLE
Fix exclude modules: avoid creating tests & examples as modules

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include *.txt
-recursive-include *.txt *.py
 recursive-include sequenticon/report_assets *
 include *.rst
 include ez_setup.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include *.txt
-recursive-include examples *.txt *.py
+recursive-include *.txt *.py
 recursive-include sequenticon/report_assets *
 include *.rst
 include ez_setup.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,4 @@ build-backend = "setuptools.build_meta"
 include-package-data = true
 
 [tool.setuptools.packages.find]
-exclude = ["docs"]
+exclude = ["docs","tests","examples"]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=open("pypi-readme.rst").read(),
     license="MIT",
     keywords="DNA sequence barcoding sequenticon identicon hash",
-    packages=find_packages(exclude="docs"),
+    packages=find_packages(exclude=["docs","tests","examples"]),
     include_package_data=True,
     install_requires=[
         "Biopython",


### PR DESCRIPTION
Both `pdf-reports` and `sequenticon` are creating "modules" for `examples` and `tests`. This seems erroneous, and in fact they end up clobbering each other. Neither of these should be doing this (packages should stick to their namespace).